### PR TITLE
Adding configurable health ports.

### DIFF
--- a/cmd/farva/main.go
+++ b/cmd/farva/main.go
@@ -16,8 +16,8 @@ func main() {
 	fs.DurationVar(&cfg.RefreshInterval, "refresh-interval", 30*time.Second, "Attempt to build and reload a new nginx config at this interval")
 	fs.StringVar(&cfg.KubeconfigFile, "kubeconfig", "", "Set this to provide an explicit path to a kubeconfig, otherwise the in-cluster config will be used.")
 	fs.BoolVar(&cfg.NGINXDryRun, "nginx-dry-run", false, "Log nginx management commands rather than executing them.")
-	fs.IntVar(&cfg.NGINXHealthPort, "nginx-health-port", 7332, "Port to listen on for nginx health checks.")
-	fs.IntVar(&cfg.FarvaHealthPort, "farva-health-port", 7333, "Port to listen on for farva health checks.")
+	fs.IntVar(&cfg.NGINXHealthPort, "nginx-health-port", gateway.DefaultNGINXConfig.HealthPort, "Port to listen on for nginx health checks.")
+	fs.IntVar(&cfg.FarvaHealthPort, "farva-health-port", gateway.DefaultFarvaHealthPort, "Port to listen on for farva health checks.")
 
 	fs.Parse(os.Args[1:])
 

--- a/cmd/farva/main.go
+++ b/cmd/farva/main.go
@@ -16,6 +16,8 @@ func main() {
 	fs.DurationVar(&cfg.RefreshInterval, "refresh-interval", 30*time.Second, "Attempt to build and reload a new nginx config at this interval")
 	fs.StringVar(&cfg.KubeconfigFile, "kubeconfig", "", "Set this to provide an explicit path to a kubeconfig, otherwise the in-cluster config will be used.")
 	fs.BoolVar(&cfg.NGINXDryRun, "nginx-dry-run", false, "Log nginx management commands rather than executing them.")
+	fs.IntVar(&cfg.NGINXHealthPort, "nginx-health-port", 7332, "Port to listen on for nginx health checks.")
+	fs.IntVar(&cfg.FarvaHealthPort, "farva-health-port", 7333, "Port to listen on for farva health checks.")
 
 	fs.Parse(os.Args[1:])
 

--- a/pkg/gateway/gateway.go
+++ b/pkg/gateway/gateway.go
@@ -7,12 +7,12 @@ import (
 	"time"
 )
 
-const HealthPort = 7333
-
 type Config struct {
 	RefreshInterval time.Duration
 	KubeconfigFile  string
 	NGINXDryRun     bool
+	NGINXHealthPort int
+	FarvaHealthPort int
 }
 
 func New(cfg Config) (*Gateway, error) {
@@ -25,9 +25,9 @@ func New(cfg Config) (*Gateway, error) {
 
 	var nm NGINXManager
 	if cfg.NGINXDryRun {
-		nm = newLoggingNGINXManager()
+		nm = newLoggingNGINXManager(cfg.NGINXHealthPort)
 	} else {
-		nm = newNGINXManager()
+		nm = newNGINXManager(cfg.NGINXHealthPort)
 	}
 
 	gw := Gateway{
@@ -74,7 +74,7 @@ func (gw *Gateway) startHTTPServer() {
 	})
 
 	s := &http.Server{
-		Addr:    fmt.Sprintf(":%d", HealthPort),
+		Addr:    fmt.Sprintf(":%d", gw.cfg.FarvaHealthPort),
 		Handler: mux,
 	}
 

--- a/pkg/gateway/gateway.go
+++ b/pkg/gateway/gateway.go
@@ -25,12 +25,14 @@ func New(cfg Config) (*Gateway, error) {
 
 	sm := newServiceMapper(kc)
 
+	nginxCfg := newNGINXConfig(cfg.NGINXHealthPort)
 	var nm NGINXManager
 	if cfg.NGINXDryRun {
-		nm = newLoggingNGINXManager(newNGINXConfig(cfg.NGINXHealthPort))
+		nm = newLoggingNGINXManager()
 	} else {
-		nm = newNGINXManager(newNGINXConfig(cfg.NGINXHealthPort))
+		nm = newNGINXManager(nginxCfg)
 	}
+	log.Printf("Using nginx config: %+v", nginxCfg)
 
 	gw := Gateway{
 		cfg: cfg,

--- a/pkg/gateway/gateway.go
+++ b/pkg/gateway/gateway.go
@@ -15,6 +15,8 @@ type Config struct {
 	FarvaHealthPort int
 }
 
+const DefaultFarvaHealthPort = 7333
+
 func New(cfg Config) (*Gateway, error) {
 	kc, err := newKubernetesClient(cfg.KubeconfigFile)
 	if err != nil {
@@ -25,9 +27,9 @@ func New(cfg Config) (*Gateway, error) {
 
 	var nm NGINXManager
 	if cfg.NGINXDryRun {
-		nm = newLoggingNGINXManager(cfg.NGINXHealthPort)
+		nm = newLoggingNGINXManager(newNGINXConfig(cfg.NGINXHealthPort))
 	} else {
-		nm = newNGINXManager(cfg.NGINXHealthPort)
+		nm = newNGINXManager(newNGINXConfig(cfg.NGINXHealthPort))
 	}
 
 	gw := Gateway{

--- a/pkg/gateway/nginx.go
+++ b/pkg/gateway/nginx.go
@@ -75,8 +75,8 @@ type NGINXManager interface {
 	Reload() error
 }
 
-func newNGINXManager(hp int) NGINXManager {
-	return &nginxManager{cfg: newNGINXConfig(hp)}
+func newNGINXManager(cfg NGINXConfig) NGINXManager {
+	return &nginxManager{cfg: cfg}
 }
 
 type nginxManager struct {
@@ -151,10 +151,10 @@ func renderConfig(cfg *NGINXConfig, sm *ServiceMap) ([]byte, error) {
 	return buf.Bytes(), nil
 }
 
-func newLoggingNGINXManager(hp int) NGINXManager {
+func newLoggingNGINXManager(cfg NGINXConfig) NGINXManager {
 	manager := loggingNGINXManager{
 		status: nginxStatusStopped,
-		cfg:    newNGINXConfig(hp),
+		cfg:    cfg,
 	}
 	log.Printf("created newLoggingNGINXManager: %+v", manager)
 	return &manager

--- a/pkg/gateway/nginx.go
+++ b/pkg/gateway/nginx.go
@@ -20,7 +20,7 @@ events {
 
 http {
     server {
-        listen 7332;
+        listen {{ .NGINXConfig.HealthPort }};
         location /health {
             return 200 'Healthy!';
         }
@@ -46,6 +46,7 @@ http {
 	DefaultNGINXConfig = NGINXConfig{
 		ConfigFile: "/etc/nginx/nginx.conf",
 		PIDFile:    "/var/run/nginx.pid",
+		HealthPort: 7332,
 	}
 )
 
@@ -58,6 +59,13 @@ const (
 type NGINXConfig struct {
 	ConfigFile string
 	PIDFile    string
+	HealthPort int
+}
+
+func newNGINXConfig(hp int) NGINXConfig {
+	cfg := DefaultNGINXConfig
+	cfg.HealthPort = hp
+	return cfg
 }
 
 type NGINXManager interface {
@@ -67,8 +75,8 @@ type NGINXManager interface {
 	Reload() error
 }
 
-func newNGINXManager() NGINXManager {
-	return &nginxManager{cfg: DefaultNGINXConfig}
+func newNGINXManager(hp int) NGINXManager {
+	return &nginxManager{cfg: newNGINXConfig(hp)}
 }
 
 type nginxManager struct {
@@ -143,12 +151,18 @@ func renderConfig(cfg *NGINXConfig, sm *ServiceMap) ([]byte, error) {
 	return buf.Bytes(), nil
 }
 
-func newLoggingNGINXManager() NGINXManager {
-	return &loggingNGINXManager{status: nginxStatusStopped}
+func newLoggingNGINXManager(hp int) NGINXManager {
+	manager := loggingNGINXManager{
+		status: nginxStatusStopped,
+		cfg:    newNGINXConfig(hp),
+	}
+	log.Printf("created newLoggingNGINXManager: %+v", manager)
+	return &manager
 }
 
 type loggingNGINXManager struct {
 	status string
+	cfg    NGINXConfig
 }
 
 func (l *loggingNGINXManager) Status() (string, error) {

--- a/pkg/gateway/nginx.go
+++ b/pkg/gateway/nginx.go
@@ -151,18 +151,12 @@ func renderConfig(cfg *NGINXConfig, sm *ServiceMap) ([]byte, error) {
 	return buf.Bytes(), nil
 }
 
-func newLoggingNGINXManager(cfg NGINXConfig) NGINXManager {
-	manager := loggingNGINXManager{
-		status: nginxStatusStopped,
-		cfg:    cfg,
-	}
-	log.Printf("created newLoggingNGINXManager: %+v", manager)
-	return &manager
+func newLoggingNGINXManager() NGINXManager {
+	return &loggingNGINXManager{status: nginxStatusStopped}
 }
 
 type loggingNGINXManager struct {
 	status string
-	cfg    NGINXConfig
 }
 
 func (l *loggingNGINXManager) Status() (string, error) {


### PR DESCRIPTION
The Farva process and our configured NGINX instance both expose health ports.
Some deployments may wish to override these values.

This PR adds two new command line arguments:
 - --farva-health-port
 - --nginx-health-port

As well as their requisite configuration.