### PR TITLE
Removing wercker specific folders.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,7 @@
 /bin
+
+# Wercker specific
+_builds
+_cache
+_projects
+_steps


### PR DESCRIPTION
The wercker-cli creates these folders locally when used to build a project.
There's currently no `dev` config in our wercker.yml so this is strictly
a proactive step.