### PR TITLE
Use labels to generate vanity urls.

### DIFF
--- a/cmd/farva-gateway/main.go
+++ b/cmd/farva-gateway/main.go
@@ -20,7 +20,7 @@ func main() {
 	fs.IntVar(&cfg.NGINXHealthPort, "nginx-health-port", gateway.DefaultNGINXConfig.HealthPort, "Port to listen on for nginx health checks.")
 	fs.IntVar(&cfg.FarvaHealthPort, "farva-health-port", gateway.DefaultFarvaHealthPort, "Port to listen on for farva health checks.")
 	fs.StringVar(&cfg.ClusterZone, "cluster-zone", "", "Use this DNS zone for routing of traffic to Kubernetes")
-	fs.StringVar(&cfg.AnnotationPrefix, "annotation-zone", gateway.DefaultServiceMapperConfig.AnnotationPrefix, "Forms the lookup key for additional gateway configuration annotations.")
+	fs.StringVar(&cfg.AnnotationPrefix, "annotation-prefix", gateway.DefaultServiceMapperConfig.AnnotationPrefix, "Forms the lookup key for additional gateway configuration annotations.")
 
 	fs.Parse(os.Args[1:])
 

--- a/cmd/farva-gateway/main.go
+++ b/cmd/farva-gateway/main.go
@@ -20,6 +20,8 @@ func main() {
 	fs.IntVar(&cfg.NGINXHealthPort, "nginx-health-port", gateway.DefaultNGINXConfig.HealthPort, "Port to listen on for nginx health checks.")
 	fs.IntVar(&cfg.FarvaHealthPort, "farva-health-port", gateway.DefaultFarvaHealthPort, "Port to listen on for farva health checks.")
 	fs.StringVar(&cfg.ClusterZone, "cluster-zone", "", "Use this DNS zone for routing of traffic to Kubernetes")
+	fs.StringVar(&cfg.AnnotationZone, "annotation-zone", kubernetes.DefaultServiceMapperConfig.AnnotationZone, "Forms the lookup key for additional gateway configuration annotations.")
+	fs.StringVar(&cfg.AliasAnnotation, "alias-annotation", kubernetes.DefaultServiceMapperConfig.AnnotationLabel, "Forms the lookup key for vanity hostnames.")
 
 	fs.Parse(os.Args[1:])
 

--- a/cmd/farva-gateway/main.go
+++ b/cmd/farva-gateway/main.go
@@ -20,8 +20,7 @@ func main() {
 	fs.IntVar(&cfg.NGINXHealthPort, "nginx-health-port", gateway.DefaultNGINXConfig.HealthPort, "Port to listen on for nginx health checks.")
 	fs.IntVar(&cfg.FarvaHealthPort, "farva-health-port", gateway.DefaultFarvaHealthPort, "Port to listen on for farva health checks.")
 	fs.StringVar(&cfg.ClusterZone, "cluster-zone", "", "Use this DNS zone for routing of traffic to Kubernetes")
-	fs.StringVar(&cfg.AnnotationZone, "annotation-zone", kubernetes.DefaultServiceMapperConfig.AnnotationZone, "Forms the lookup key for additional gateway configuration annotations.")
-	fs.StringVar(&cfg.AliasAnnotation, "alias-annotation", kubernetes.DefaultServiceMapperConfig.AnnotationLabel, "Forms the lookup key for vanity hostnames.")
+	fs.StringVar(&cfg.AnnotationPrefix, "annotation-zone", gateway.DefaultServiceMapperConfig.AnnotationPrefix, "Forms the lookup key for additional gateway configuration annotations.")
 
 	fs.Parse(os.Args[1:])
 

--- a/pkg/gateway/gateway.go
+++ b/pkg/gateway/gateway.go
@@ -16,6 +16,8 @@ type Config struct {
 	NGINXDryRun     bool
 	NGINXHealthPort int
 	FarvaHealthPort int
+	AnnotationZone  string
+	AliasAnnotation string
 }
 
 const DefaultFarvaHealthPort = 7333
@@ -26,7 +28,11 @@ func New(cfg Config) (*Gateway, error) {
 		return nil, err
 	}
 
-	sm := newServiceMapper(kc)
+	smcfg := &ServiceMapperConfig{
+		AnnotationZone:  cfg.AnnotationZone,
+		AliasAnnotation: cfg.AliasAnnotation,
+	}
+	sm := newServiceMapper(kc, smcfg)
 
 	nginxCfg := newNGINXConfig(cfg.NGINXHealthPort, cfg.ClusterZone)
 	var nm NGINXManager

--- a/pkg/gateway/gateway.go
+++ b/pkg/gateway/gateway.go
@@ -10,14 +10,13 @@ import (
 )
 
 type Config struct {
-	RefreshInterval time.Duration
-	KubeconfigFile  string
-	ClusterZone     string
-	NGINXDryRun     bool
-	NGINXHealthPort int
-	FarvaHealthPort int
-	AnnotationZone  string
-	AliasAnnotation string
+	RefreshInterval  time.Duration
+	KubeconfigFile   string
+	ClusterZone      string
+	NGINXDryRun      bool
+	NGINXHealthPort  int
+	FarvaHealthPort  int
+	AnnotationPrefix string
 }
 
 const DefaultFarvaHealthPort = 7333
@@ -29,8 +28,7 @@ func New(cfg Config) (*Gateway, error) {
 	}
 
 	smcfg := &ServiceMapperConfig{
-		AnnotationZone:  cfg.AnnotationZone,
-		AliasAnnotation: cfg.AliasAnnotation,
+		AnnotationPrefix: cfg.AnnotationPrefix,
 	}
 	sm := newServiceMapper(kc, smcfg)
 

--- a/pkg/gateway/kubernetes.go
+++ b/pkg/gateway/kubernetes.go
@@ -9,7 +9,7 @@ import (
 	"log"
 )
 
-const VanityConfigMapName = "FarvaVanityUrls"
+const VanityConfigMapName = "farva-vanity-urls"
 
 func newKubernetesClient(kubeconfig string) (*kclient.Client, error) {
 	cfg, err := getKubernetesClientConfig(kubeconfig)

--- a/pkg/gateway/kubernetes.go
+++ b/pkg/gateway/kubernetes.go
@@ -90,13 +90,16 @@ func setServiceEndpoints(svc *Service, asm *apiServiceMapper) error {
 	return nil
 }
 
-func (asm *apiServiceMapper) aliases() (*Aliases, error) {
+func (asm *apiServiceMapper) aliases() (*AliasMap, error) {
 	vanityUrls, err := asm.kc.ConfigMaps(kapi.NamespaceAll).Get(VanityConfigMapName)
 	if err != nil {
 		return nil, err
 	} else {
-		aliases := &Aliases{Data: vanityUrls.Data}
-		return aliases, nil
+		aliases := AliasMap{}
+		for key, val := range vanityUrls.Data {
+			aliases[key] = val
+		}
+		return &aliases, nil
 	}
 }
 
@@ -113,7 +116,7 @@ func (asm *apiServiceMapper) ServiceMap() (*ServiceMap, error) {
 			VanityConfigMapName,
 			err,
 		)
-		aliases = &Aliases{Data: map[string]string{}}
+		aliases = &AliasMap{}
 	}
 
 	var serviceGroups []ServiceGroup
@@ -170,6 +173,6 @@ func (asm *apiServiceMapper) ServiceMap() (*ServiceMap, error) {
 		serviceGroups = append(serviceGroups, svg)
 	}
 
-	sm := &ServiceMap{ServiceGroups: serviceGroups, Aliases: aliases}
+	sm := &ServiceMap{ServiceGroups: serviceGroups, AliasMap: aliases}
 	return sm, nil
 }

--- a/pkg/gateway/nginx.go
+++ b/pkg/gateway/nginx.go
@@ -35,7 +35,7 @@ http {
 {{ range $svg := .ServiceMap.ServiceGroups }}
     server {
         listen {{ $.NGINXConfig.ListenPort }};
-        server_name {{ $svg.DefaultServerName $.NGINXConfig.ClusterZone }} {{ $.ServiceMap.Aliases.AliasNames $svg.Name $svg.Namespace }};
+        server_name {{ $svg.DefaultServerName $.NGINXConfig.ClusterZone }} {{ range $.ServiceMap.AliasMap.FilterByIngress $svg.Name $svg.Namespace }}{{ . }}{{ end }};
 {{ range $svc := $svg.Services }}
         location {{ or $svc.Path "/" }} {
             proxy_pass http://{{ $svc.Namespace }}__{{ $svg.Name }}__{{ $svc.Name }};

--- a/pkg/gateway/nginx.go
+++ b/pkg/gateway/nginx.go
@@ -35,7 +35,7 @@ http {
 {{ range $svg := .ServiceMap.ServiceGroups }}
     server {
         listen {{ $.NGINXConfig.ListenPort }};
-        server_name {{ $svg.DefaultServerName $.NGINXConfig.ClusterZone }} {{ range $.ServiceMap.AliasMap.FilterByIngress $svg.Name $svg.Namespace }}{{ . }}{{ end }};
+        server_name {{ $svg.DefaultServerName $.NGINXConfig.ClusterZone }} {{ range $svg.Aliases }}{{ . }}{{ end }};
 {{ range $svc := $svg.Services }}
         location {{ or $svc.Path "/" }} {
             proxy_pass http://{{ $svc.Namespace }}__{{ $svg.Name }}__{{ $svc.Name }};

--- a/pkg/gateway/nginx.go
+++ b/pkg/gateway/nginx.go
@@ -35,7 +35,7 @@ http {
 {{ range $svg := .ServiceMap.ServiceGroups }}
     server {
         listen {{ $.NGINXConfig.ListenPort }};
-        server_name {{ $svg.DefaultServerName $.NGINXConfig.ClusterZone }};
+        server_name {{ $svg.DefaultServerName $.NGINXConfig.ClusterZone }} {{ $.ServiceMap.Aliases.AliasNames $svg.Name $svg.Namespace }};
 {{ range $svc := $svg.Services }}
         location {{ or $svc.Path "/" }} {
             proxy_pass http://{{ $svc.Namespace }}__{{ $svg.Name }}__{{ $svc.Name }};

--- a/pkg/gateway/nginx_test.go
+++ b/pkg/gateway/nginx_test.go
@@ -17,11 +17,11 @@ func (fsm *fakeServiceMapper) ServiceMap() (*ServiceMap, error) {
 func TestRender(t *testing.T) {
 	fsm := fakeServiceMapper{
 		sm: ServiceMap{
-			AliasMap: &AliasMap{
-				"apps.example.com": "ing1.ns1",
-			},
 			ServiceGroups: []ServiceGroup{
 				ServiceGroup{
+					Aliases: []string{
+						"apps.example.com",
+					},
 					Name:      "ing1",
 					Namespace: "ns1",
 					Services: []Service{

--- a/pkg/gateway/nginx_test.go
+++ b/pkg/gateway/nginx_test.go
@@ -17,10 +17,15 @@ func (fsm *fakeServiceMapper) ServiceMap() (*ServiceMap, error) {
 func TestRender(t *testing.T) {
 	fsm := fakeServiceMapper{
 		sm: ServiceMap{
+			Aliases: &Aliases{
+				Data: map[string]string{
+					"apps.example.com": "ing1.ns1",
+				},
+			},
 			ServiceGroups: []ServiceGroup{
 				ServiceGroup{
 					Name:      "ing1",
-					Namespace: "svc1",
+					Namespace: "ns1",
 					Services: []Service{
 						Service{
 							Namespace: "ns1",
@@ -78,7 +83,7 @@ http {
 
     server {
         listen 7331;
-        server_name ing1.svc1.example.com;
+        server_name ing1.ns1.example.com apps.example.com;
 
         location / {
             proxy_pass http://ns1__ing1__svc1;

--- a/pkg/gateway/nginx_test.go
+++ b/pkg/gateway/nginx_test.go
@@ -17,10 +17,8 @@ func (fsm *fakeServiceMapper) ServiceMap() (*ServiceMap, error) {
 func TestRender(t *testing.T) {
 	fsm := fakeServiceMapper{
 		sm: ServiceMap{
-			Aliases: &Aliases{
-				Data: map[string]string{
-					"apps.example.com": "ing1.ns1",
-				},
+			AliasMap: &AliasMap{
+				"apps.example.com": "ing1.ns1",
 			},
 			ServiceGroups: []ServiceGroup{
 				ServiceGroup{

--- a/pkg/gateway/servicemap.go
+++ b/pkg/gateway/servicemap.go
@@ -10,7 +10,6 @@ type ServiceMapper interface {
 
 type ServiceMap struct {
 	ServiceGroups []ServiceGroup
-	AliasMap      *AliasMap
 }
 
 type Service struct {
@@ -22,6 +21,7 @@ type Service struct {
 }
 
 type ServiceGroup struct {
+	Aliases   []string
 	Name      string
 	Namespace string
 	Services  []Service
@@ -40,17 +40,4 @@ type Endpoint struct {
 	Name string
 	IP   string
 	Port int
-}
-
-type AliasMap map[string]string
-
-// Generates a list of aliases for a given ingress name and namespace.
-func (a *AliasMap) FilterByIngress(name string, ns string) []string {
-	results := make([]string, 0)
-	for key, value := range *a {
-		if value == fmt.Sprintf("%s.%s", name, ns) {
-			results = append(results, key)
-		}
-	}
-	return results
 }

--- a/pkg/gateway/servicemap.go
+++ b/pkg/gateway/servicemap.go
@@ -2,7 +2,6 @@ package gateway
 
 import (
 	"fmt"
-	"strings"
 )
 
 type ServiceMapper interface {
@@ -11,7 +10,7 @@ type ServiceMapper interface {
 
 type ServiceMap struct {
 	ServiceGroups []ServiceGroup
-	Aliases       *Aliases
+	AliasMap      *AliasMap
 }
 
 type Service struct {
@@ -25,7 +24,6 @@ type Service struct {
 type ServiceGroup struct {
 	Name      string
 	Namespace string
-	Aliases   *Aliases
 	Services  []Service
 }
 
@@ -44,23 +42,15 @@ type Endpoint struct {
 	Port int
 }
 
-type Aliases struct {
-	Data map[string]string
-}
+type AliasMap map[string]string
 
 // Generates a list of aliases for a given ingress name and namespace.
-func (a *Aliases) Collect(name string, ns string) []string {
+func (a *AliasMap) FilterByIngress(name string, ns string) []string {
 	results := make([]string, 0)
-	for key, value := range a.Data {
+	for key, value := range *a {
 		if value == fmt.Sprintf("%s.%s", name, ns) {
 			results = append(results, key)
 		}
 	}
 	return results
-}
-
-// Generates a concatenated list of aliases for a given ingress name and namespace.
-func (a *Aliases) AliasNames(name string, ns string) string {
-	aliases := a.Collect(name, ns)
-	return strings.Join(aliases, " ")
 }

--- a/pkg/gateway/servicemap.go
+++ b/pkg/gateway/servicemap.go
@@ -2,6 +2,7 @@ package gateway
 
 import (
 	"fmt"
+	"strings"
 )
 
 type ServiceMapper interface {
@@ -10,6 +11,7 @@ type ServiceMapper interface {
 
 type ServiceMap struct {
 	ServiceGroups []ServiceGroup
+	Aliases       *Aliases
 }
 
 type Service struct {
@@ -23,7 +25,7 @@ type Service struct {
 type ServiceGroup struct {
 	Name      string
 	Namespace string
-	Aliases   []string
+	Aliases   *Aliases
 	Services  []Service
 }
 
@@ -40,4 +42,25 @@ type Endpoint struct {
 	Name string
 	IP   string
 	Port int
+}
+
+type Aliases struct {
+	Data map[string]string
+}
+
+// Generates a list of aliases for a given ingress name and namespace.
+func (a *Aliases) Collect(name string, ns string) []string {
+	results := make([]string, 0)
+	for key, value := range a.Data {
+		if value == fmt.Sprintf("%s.%s", name, ns) {
+			results = append(results, key)
+		}
+	}
+	return results
+}
+
+// Generates a concatenated list of aliases for a given ingress name and namespace.
+func (a *Aliases) AliasNames(name string, ns string) string {
+	aliases := a.Collect(name, ns)
+	return strings.Join(aliases, " ")
 }


### PR DESCRIPTION
This commit adds support for using a Kubernetes ConfigMap to populate
server_name aliases for a given ingress Name and Namespace. The config map name
is hard coded to `FarvaVanityUrls`. The expected format is:

		"app.vanity.com": "ing1.ns1"

Where `app.vanity.com` is the vanity name we want to expose and "ing1.ns1"
corresponds to a name of "ing1" and namespace of "ns1".

Multiple vanity urls can be created for a ingress single name and namespace.
