### PR TITLE
Logging (& fixes)

### DIFF
--- a/cmd/farva-gateway/main.go
+++ b/cmd/farva-gateway/main.go
@@ -18,7 +18,8 @@ func main() {
 	fs.StringVar(&cfg.KubeconfigFile, "kubeconfig", "", "Set this to provide an explicit path to a kubeconfig, otherwise the in-cluster config will be used.")
 	fs.BoolVar(&cfg.NGINXDryRun, "nginx-dry-run", false, "Log nginx management commands rather than executing them.")
 	fs.IntVar(&cfg.NGINXHealthPort, "nginx-health-port", gateway.DefaultNGINXConfig.HealthPort, "Port to listen on for nginx health checks.")
-	fs.IntVar(&cfg.FarvaHealthPort, "farva-health-port", gateway.DefaultFarvaHealthPort, "Port to listen on for farva health checks.")
+	fs.IntVar(&cfg.FarvaHealthPort, "farva-health-port", gateway.DefaultConfig.FarvaHealthPort, "Port to listen on for farva health checks.")
+	fs.IntVar(&cfg.HTTPListenPort, "http-listen-port", gateway.DefaultConfig.HTTPListenPort, "Port to listen on for HTTP traffic.")
 	fs.StringVar(&cfg.ClusterZone, "cluster-zone", "", "Use this DNS zone for routing of traffic to Kubernetes")
 	fs.StringVar(&cfg.AnnotationPrefix, "annotation-prefix", gateway.DefaultKubernetesReverseProxyConfigGetterConfig.AnnotationPrefix, "Forms the lookup key for additional gateway configuration annotations.")
 

--- a/pkg/gateway/gateway.go
+++ b/pkg/gateway/gateway.go
@@ -70,7 +70,7 @@ func New(cfg Config) (*Gateway, error) {
 	} else {
 		nm = newNGINXManager(nginxCfg)
 	}
-	logger.Log.Info("Using nginx config: %+v", nginxCfg)
+	logger.Log.Infof("Using nginx config: %+v", nginxCfg)
 
 	gw := Gateway{
 		cfg: cfg,

--- a/pkg/gateway/gateway.go
+++ b/pkg/gateway/gateway.go
@@ -2,11 +2,11 @@ package gateway
 
 import (
 	"fmt"
-	"log"
 	"net/http"
 	"time"
 
 	"github.com/bcwaldon/farva/pkg/health"
+	"github.com/bcwaldon/farva/pkg/logger"
 )
 
 type Config struct {
@@ -70,7 +70,7 @@ func New(cfg Config) (*Gateway, error) {
 	} else {
 		nm = newNGINXManager(nginxCfg)
 	}
-	log.Printf("Using nginx config: %+v", nginxCfg)
+	logger.Log.Info("Using nginx config: %+v", nginxCfg)
 
 	gw := Gateway{
 		cfg: cfg,
@@ -116,12 +116,12 @@ func (gw *Gateway) startHTTPServer() {
 	}
 
 	go func() {
-		log.Fatal(s.ListenAndServe())
+		logger.Log.Fatal(s.ListenAndServe())
 	}()
 }
 
 func (gw *Gateway) nginxIsRunning() (bool, error) {
-	log.Printf("Checking if nginx is running")
+	logger.Log.Info("Checking if nginx is running")
 	st, err := gw.nm.Status()
 	if err != nil {
 		return false, err
@@ -130,7 +130,7 @@ func (gw *Gateway) nginxIsRunning() (bool, error) {
 }
 
 func (gw *Gateway) refresh() error {
-	log.Printf("Refreshing nginx config")
+	logger.Log.Info("Refreshing nginx config")
 	rc, err := gw.rg.ReverseProxyConfig()
 	if err != nil {
 		return err
@@ -153,13 +153,13 @@ func (gw *Gateway) Run() error {
 		return err
 	}
 
-	log.Printf("Gateway started successfully, entering refresh loop")
+	logger.Log.Info("Gateway started successfully, entering refresh loop")
 
 	ticker := time.NewTicker(gw.cfg.RefreshInterval)
 
 	for {
 		if err := gw.refresh(); err != nil {
-			log.Printf("Failed refreshing Gateway: %v", err)
+			logger.Log.Infof("Failed refreshing Gateway: %v", err)
 		}
 
 		//NOTE(bcwaldon): receive from the ticker at the

--- a/pkg/gateway/reverseproxy_nginx.go
+++ b/pkg/gateway/reverseproxy_nginx.go
@@ -2,8 +2,8 @@ package gateway
 
 import (
 	"bytes"
+	"github.com/bcwaldon/farva/pkg/logger"
 	"io/ioutil"
-	"log"
 	"os"
 	"os/exec"
 	"text/template"
@@ -111,7 +111,7 @@ type nginxManager struct {
 }
 
 func (n *nginxManager) Status() (string, error) {
-	log.Printf("Checking status")
+	logger.Log.Info("Checking status")
 	if _, err := os.Stat(n.cfg.PIDFile); err != nil {
 		if os.IsNotExist(err) {
 			return nginxStatusStopped, nil
@@ -125,6 +125,7 @@ func (n *nginxManager) Status() (string, error) {
 
 func (n *nginxManager) WriteConfig(rc *reverseProxyConfig) error {
 	cfg, err := renderConfig(&n.cfg, rc)
+	logger.Log.Infof("About to write config: %s", string(cfg))
 	if err != nil {
 		return err
 	}
@@ -135,34 +136,53 @@ func (n *nginxManager) WriteConfig(rc *reverseProxyConfig) error {
 }
 
 func (n *nginxManager) assertConfigOK() error {
-	return n.run("-t")
+	_, err := n.runCombinedOutput("-t")
+	return err
 }
 
 func (n *nginxManager) Start() error {
-	log.Printf("Starting nginx")
-	return n.run()
+	if err := n.assertConfigOK(); err != nil {
+		logger.Log.Info("Configuration is invalid, aborting start")
+		return err
+	} else {
+		logger.Log.Info("Starting nginx")
+		return n.run()
+	}
 }
 
 func (n *nginxManager) Reload() error {
-	log.Printf("Reloading nginx")
+	logger.Log.Info("Reloading nginx")
 	return n.run("-s", "reload")
 }
 
 func (n *nginxManager) run(args ...string) error {
 	args = append([]string{"-c", n.cfg.ConfigFile}, args...)
-	log.Printf("Calling run on nginx with args: %q", args)
+	logger.Log.Infof("Calling run on nginx with args: %q", args)
 	err := exec.Command("nginx", args...).Run()
 	if err != nil {
-		log.Printf("nginx command failed w/ err: %v", err)
+		logger.Log.Infof("nginx command failed w/ err: %v", err)
 		return err
 	} else {
-		log.Printf("nginx command success")
+		logger.Log.Info("nginx command success")
 	}
 	return nil
 }
 
+func (n *nginxManager) runCombinedOutput(args ...string) (string, error) {
+	args = append([]string{"-c", n.cfg.ConfigFile}, args...)
+	logger.Log.Infof("Calling run on nginx with args: %q", args)
+	output, err := exec.Command("nginx", args...).CombinedOutput()
+	if err != nil {
+		logger.Log.Infof("nginx command failed w/ err: %v, output:%s", err, output)
+		return "", err
+	} else {
+		logger.Log.Info("nginx command success")
+	}
+	return string(output), nil
+}
+
 func renderConfig(cfg *NGINXConfig, rc *reverseProxyConfig) ([]byte, error) {
-	log.Printf("Rendering config")
+	logger.Log.Info("Rendering config")
 
 	config := struct {
 		ReverseProxyConfig *reverseProxyConfig
@@ -188,22 +208,22 @@ type loggingNGINXManager struct {
 }
 
 func (l *loggingNGINXManager) Status() (string, error) {
-	log.Printf("called NGINXManager.Status()")
+	logger.Log.Info("called NGINXManager.Status()")
 	return l.status, nil
 }
 
 func (l *loggingNGINXManager) Start() error {
-	log.Printf("called NGINXManager.Start()")
+	logger.Log.Info("called NGINXManager.Start()")
 	l.status = nginxStatusRunning
 	return nil
 }
 
 func (l *loggingNGINXManager) Reload() error {
-	log.Printf("called NGINXManager.Reload()")
+	logger.Log.Info("called NGINXManager.Reload()")
 	return nil
 }
 
 func (l *loggingNGINXManager) WriteConfig(rc *reverseProxyConfig) error {
-	log.Printf("called NGINXManager.WriteConfig(*reverseProxyConfig) w/ %+v", rc)
+	logger.Log.Infof("called NGINXManager.WriteConfig(*reverseProxyConfig) w/ %+v", rc)
 	return nil
 }

--- a/pkg/gateway/reverseproxy_nginx.go
+++ b/pkg/gateway/reverseproxy_nginx.go
@@ -71,6 +71,7 @@ stream {
 		ClusterZone: "example.com",
 		ConfigFile:  "/etc/nginx/nginx.conf",
 		PIDFile:     "/var/run/nginx.pid",
+		HealthPort:  7332,
 	}
 )
 

--- a/pkg/gateway/reverseproxy_nginx.go
+++ b/pkg/gateway/reverseproxy_nginx.go
@@ -145,13 +145,15 @@ func (n *nginxManager) Start() error {
 	if err := n.assertConfigOK(); err != nil {
 		logger.Log.Info("Configuration is invalid, aborting start")
 		return err
-	} else {
-		logger.Log.Info("Starting nginx")
-		return n.run()
 	}
+	logger.Log.Info("Starting nginx")
+	return n.run()
 }
 
 func (n *nginxManager) Reload() error {
+	if err := n.assertConfigOK(); err != nil {
+		return err
+	}
 	logger.Log.Info("Reloading nginx")
 	return n.run("-s", "reload")
 }

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -1,0 +1,12 @@
+package logger
+
+import (
+	"github.com/Sirupsen/logrus"
+)
+
+var Log = logrus.New()
+
+func init() {
+	Log.Formatter = new(logrus.TextFormatter)
+	Log.Level = logrus.DebugLevel
+}


### PR DESCRIPTION
Adopts logrus for logging. I don't believe we're getting full value from it yet. I want to experiment with formatter options to see if we can propagate these to `journalctl` in a structured fashion.

In the meantime some of the more useful details:
- Fixes to defaults that caused farva startup to fail.
- Logging of the nginx config that's generated prior to starting nginx.
- Use `CombinedOutput` and log output of `nginx -t` to better identify the source of future configuration issues.
- Explicit logging of ignored upstreams.