### PR TITLE
Read from fifo.

### DIFF
--- a/cmd/farva-gateway/main.go
+++ b/cmd/farva-gateway/main.go
@@ -20,6 +20,7 @@ func main() {
 	fs.IntVar(&cfg.NGINXHealthPort, "nginx-health-port", gateway.DefaultNGINXConfig.HealthPort, "Port to listen on for nginx health checks.")
 	fs.IntVar(&cfg.FarvaHealthPort, "farva-health-port", gateway.DefaultConfig.FarvaHealthPort, "Port to listen on for farva health checks.")
 	fs.IntVar(&cfg.HTTPListenPort, "http-listen-port", gateway.DefaultConfig.HTTPListenPort, "Port to listen on for HTTP traffic.")
+	fs.StringVar(&cfg.FifoPath, "fifo-path", gateway.DefaultConfig.FifoPath, "Location of nginx stderr and stdout logging fifo.")
 	fs.StringVar(&cfg.ClusterZone, "cluster-zone", "", "Use this DNS zone for routing of traffic to Kubernetes")
 	fs.StringVar(&cfg.AnnotationPrefix, "annotation-prefix", gateway.DefaultKubernetesReverseProxyConfigGetterConfig.AnnotationPrefix, "Forms the lookup key for additional gateway configuration annotations.")
 

--- a/pkg/gateway/reverseproxy_nginx.go
+++ b/pkg/gateway/reverseproxy_nginx.go
@@ -12,6 +12,7 @@ import (
 var (
 	nginxTemplateData = `
 pid {{ .NGINXConfig.PIDFile }};
+error_log {{ .NGINXConfig.ErrorLog }};
 daemon on;
 
 events {
@@ -20,6 +21,10 @@ events {
 
 http {
     server_names_hash_bucket_size 128;
+    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                      '$status $body_bytes_sent "$http_referer" '
+                      '"$http_user_agent" "$http_x_forwarded_for"';
+    access_log {{ .NGINXConfig.AccessLog }} main;
 {{ range $srv := $.ReverseProxyConfig.HTTPServers }}
     server {
         listen {{ $srv.ListenPort }};
@@ -72,6 +77,8 @@ stream {
 		ConfigFile:  "/etc/nginx/nginx.conf",
 		PIDFile:     "/var/run/nginx.pid",
 		HealthPort:  7332,
+		AccessLog:   "/dev/stdout",
+		ErrorLog:    "/dev/stderr",
 	}
 )
 
@@ -87,12 +94,16 @@ type NGINXConfig struct {
 	PIDFile     string
 	HealthPort  int
 	ListenPort  int
+	ErrorLog    string
+	AccessLog   string
 }
 
-func newNGINXConfig(hp int, cz string) NGINXConfig {
+func newNGINXConfig(hp int, cz string, errorLog string, accessLog string) NGINXConfig {
 	cfg := DefaultNGINXConfig
 	cfg.HealthPort = hp
 	cfg.ClusterZone = cz
+	cfg.ErrorLog = errorLog
+	cfg.AccessLog = accessLog
 	return cfg
 }
 

--- a/pkg/gateway/reverseproxy_nginx_test.go
+++ b/pkg/gateway/reverseproxy_nginx_test.go
@@ -36,6 +36,7 @@ func TestRenderConfig(t *testing.T) {
 			},
 			want: `
 pid /var/run/nginx.pid;
+error_log /dev/stderr;
 daemon on;
 
 events {
@@ -44,6 +45,10 @@ events {
 
 http {
     server_names_hash_bucket_size 128;
+    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                      '$status $body_bytes_sent "$http_referer" '
+                      '"$http_user_agent" "$http_x_forwarded_for"';
+    access_log /dev/stdout main;
 
     server {
         listen 9001;
@@ -94,6 +99,7 @@ stream {
 			},
 			want: `
 pid /var/run/nginx.pid;
+error_log /dev/stderr;
 daemon on;
 
 events {
@@ -102,6 +108,10 @@ events {
 
 http {
     server_names_hash_bucket_size 128;
+    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                      '$status $body_bytes_sent "$http_referer" '
+                      '"$http_user_agent" "$http_x_forwarded_for"';
+    access_log /dev/stdout main;
 
     server {
         listen 9001;
@@ -186,6 +196,7 @@ stream {
 			},
 			want: `
 pid /var/run/nginx.pid;
+error_log /dev/stderr;
 daemon on;
 
 events {
@@ -194,6 +205,10 @@ events {
 
 http {
     server_names_hash_bucket_size 128;
+    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                      '$status $body_bytes_sent "$http_referer" '
+                      '"$http_user_agent" "$http_x_forwarded_for"';
+    access_log /dev/stdout main;
 
     server {
         listen 9001;
@@ -276,6 +291,7 @@ stream {
 			},
 			want: `
 pid /var/run/nginx.pid;
+error_log /dev/stderr;
 daemon on;
 
 events {
@@ -284,6 +300,10 @@ events {
 
 http {
     server_names_hash_bucket_size 128;
+    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                      '$status $body_bytes_sent "$http_referer" '
+                      '"$http_user_agent" "$http_x_forwarded_for"';
+    access_log /dev/stdout main;
 
 
 }

--- a/pkg/logpipe/logpipe.go
+++ b/pkg/logpipe/logpipe.go
@@ -1,0 +1,46 @@
+package logpipe
+
+import (
+	"bufio"
+	"github.com/bcwaldon/farva/pkg/logger"
+	"os"
+	"syscall"
+)
+
+type LogPipe struct {
+	path string
+}
+
+func NewLogPipe(path string) LogPipe {
+	return LogPipe{path: path}
+}
+
+func (l *LogPipe) Start() error {
+	// Always remove the fifo initially, ignore error if it doesn't exist.
+	os.Remove(l.path)
+	if err := syscall.Mkfifo(l.path, 0777); err != nil {
+		logger.Log.Errorf("Could create fifo at %s: %s", l.path, err)
+		return err
+	}
+
+	go func() {
+		f, err := os.Open(l.path)
+		if err != nil {
+			logger.Log.Errorf("Could not open fifo: %s", err)
+			return
+		}
+
+		reader := bufio.NewReader(f)
+
+		for {
+			line, _, err := reader.ReadLine()
+			if err != nil {
+				logger.Log.Errorf("Could not read line from fifo: %s", err)
+			} else {
+				logger.Log.Printf("NGINX: %s", string(line))
+			}
+		}
+	}()
+
+	return nil
+}

--- a/pkg/logpipe/logpipe.go
+++ b/pkg/logpipe/logpipe.go
@@ -3,6 +3,7 @@ package logpipe
 import (
 	"bufio"
 	"github.com/bcwaldon/farva/pkg/logger"
+	"io"
 	"os"
 	"syscall"
 )
@@ -34,7 +35,7 @@ func (l *LogPipe) Start() error {
 
 		for {
 			line, _, err := reader.ReadLine()
-			if err != nil {
+			if err != nil && err != io.EOF {
 				logger.Log.Errorf("Could not read line from fifo: %s", err)
 			} else {
 				logger.Log.Printf("NGINX: %s", string(line))


### PR DESCRIPTION
There are a few significant caveats with this approach:

1. Error handling around failing to read from the fifo hasn't been fully
baked. 2. If farva isn't reading from the FIFO, nginx will block. 3. It
would be better if farva operated in a degraded mode without nginx logs
 if we fail to create the fifo. We could unset the error and access log
 configuration on the nginx object in this situation and omit setting
 the two directives.