### PR TITLE
Adding DefaultServer to reverse proxy config.

### DIFF
--- a/pkg/gateway/gateway.go
+++ b/pkg/gateway/gateway.go
@@ -41,8 +41,9 @@ func DefaultHTTPReverseProxyServers(cfg *Config) []httpReverseProxyServer {
 			},
 		},
 		httpReverseProxyServer{
-			ListenPort: cfg.HTTPListenPort,
-			StaticCode: 444,
+			ListenPort:    cfg.HTTPListenPort,
+			DefaultServer: true,
+			StaticCode:    444,
 		},
 	}
 }

--- a/pkg/gateway/reverseproxy.go
+++ b/pkg/gateway/reverseproxy.go
@@ -14,6 +14,7 @@ type reverseProxyConfig struct {
 type httpReverseProxyServer struct {
 	Name          string
 	AltNames      []string
+	DefaultServer bool
 	ListenPort    int
 	Locations     []httpReverseProxyLocation
 	StaticCode    int

--- a/pkg/gateway/reverseproxy_nginx.go
+++ b/pkg/gateway/reverseproxy_nginx.go
@@ -28,7 +28,7 @@ http {
     access_log {{ .NGINXConfig.AccessLog }} main;
 {{ range $srv := $.ReverseProxyConfig.HTTPServers }}
     server {
-        listen {{ $srv.ListenPort }};
+        listen {{ $srv.ListenPort }}{{ if $srv.DefaultServer }} default_server{{ end }};
         {{ if $srv.Name }}server_name {{ $srv.Name }}{{ if $srv.AltNames }} {{ join $srv.AltNames " " }}{{ end }};{{ end }}
         {{ if $srv.StaticCode -}}
         return {{ $srv.StaticCode }}{{ if $srv.StaticMessage }} '{{ $srv.StaticMessage }}'{{ end }};

--- a/pkg/gateway/reverseproxy_nginx_test.go
+++ b/pkg/gateway/reverseproxy_nginx_test.go
@@ -378,6 +378,48 @@ stream {
 }
 `,
 		},
+		// DefaultServer
+		{
+			rc: reverseProxyConfig{
+				HTTPServers: []httpReverseProxyServer{
+					httpReverseProxyServer{
+						ListenPort:    9001,
+						DefaultServer: true,
+						StaticCode:    202,
+					},
+				},
+			},
+			want: `
+pid /var/run/nginx.pid;
+error_log /dev/stderr;
+daemon on;
+
+events {
+    worker_connections 512;
+}
+
+http {
+    server_names_hash_bucket_size 128;
+    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                      '$status $body_bytes_sent "$http_referer" '
+                      '"$http_user_agent" "$http_x_forwarded_for"';
+    access_log /dev/stdout main;
+
+    server {
+        listen 9001 default_server;
+        
+        return 202;
+    }
+
+
+}
+
+stream {
+
+
+}
+`,
+		},
 	}
 
 	for i, tt := range tests {


### PR DESCRIPTION
Without this, we rely on the ordering of server blocks within the generated
nginx config in order to determine where to route traffic without a host
header. Rather than leaving it to chance, we want to explicitly indicate
that a given server is the default server.

Note: this patch makes no attempt to prevent duplicate default_servers
listening on a given port. The behavior in that case is undefiend and has
not been tested. The only code path setting it explicitly at the moment is
via `DefaultHTTPReverseProxyServers`.