### PR TITLE
Use StaticCode when a location has no upstream servers.

### DIFF
--- a/pkg/gateway/reverseproxy_nginx.go
+++ b/pkg/gateway/reverseproxy_nginx.go
@@ -46,11 +46,13 @@ http {
     }
 {{ end }}
 {{ range $up := $.ReverseProxyConfig.HTTPUpstreams }}
+{{ if $up.Servers }}
     upstream {{ $up.Name }} {
 {{ range $ep := $up.Servers }}
         server {{ $ep.Host }}:{{ $ep.Port }};  # {{ $ep.Name }}
 {{- end }}
     }
+{{- end }}
 {{ end }}
 }
 
@@ -62,11 +64,13 @@ stream {
     }
 {{ end }}
 {{ range $up := $.ReverseProxyConfig.TCPUpstreams }}
+{{ if $up.Servers }}
     upstream {{ $up.Name }} {
 {{ range $ep := $up.Servers }}
         server {{ $ep.Host }}:{{ $ep.Port }};  # {{ $ep.Name }}
 {{- end }}
     }
+{{- end }}
 {{ end }}
 }
 `

--- a/pkg/gateway/reverseproxy_nginx_test.go
+++ b/pkg/gateway/reverseproxy_nginx_test.go
@@ -227,11 +227,13 @@ http {
     }
 
 
+
     upstream foo {
 
         server ping.example.com:443;  # ping
         server pong.example.com:80;  # pong
     }
+
 
     upstream bar {
 
@@ -321,10 +323,12 @@ stream {
     }
 
 
+
     upstream foo {
 
         server ping.example.com:443;  # ping
     }
+
 
     upstream bar {
 
@@ -415,6 +419,51 @@ http {
 }
 
 stream {
+
+
+}
+`,
+		},
+		// A Server with no upstreams.
+		{
+			rc: reverseProxyConfig{
+				HTTPUpstreams: []httpReverseProxyUpstream{
+					httpReverseProxyUpstream{
+						Name:    "foo",
+						Servers: []reverseProxyUpstreamServer{},
+					},
+				},
+				TCPUpstreams: []tcpReverseProxyUpstream{
+					tcpReverseProxyUpstream{
+						Name:    "foo",
+						Servers: []reverseProxyUpstreamServer{},
+					},
+				},
+			},
+			want: `
+pid /var/run/nginx.pid;
+error_log /dev/stderr;
+daemon on;
+
+events {
+    worker_connections 512;
+}
+
+http {
+    server_names_hash_bucket_size 128;
+    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                      '$status $body_bytes_sent "$http_referer" '
+                      '"$http_user_agent" "$http_x_forwarded_for"';
+    access_log /dev/stdout main;
+
+
+
+
+}
+
+stream {
+
+
 
 
 }


### PR DESCRIPTION
Farva cannot render valid upstream blocks when there are no servers
discovered, therefore we do not render upstreams without servers.

Since we do not render upstreams without servers, we cannot refer to these
invalid upstream blocks by name. We defend against this situation when
reading from the k8s API's by configuring the invalid
httpReverseProxyLocation to return a static 503 instead of proxying to it's
invalid upstreams.