### PR TITLE
Don't reload nginx and configuration when unchanged.

### DIFF
--- a/pkg/gateway/gateway.go
+++ b/pkg/gateway/gateway.go
@@ -100,7 +100,7 @@ func (gw *Gateway) start() error {
 	}
 
 	rc := DefaultReverseProxyConfig(&gw.cfg)
-	if err := gw.nm.WriteConfig(rc); err != nil {
+	if err := gw.nm.SetConfig(rc); err != nil {
 		return err
 	}
 
@@ -142,13 +142,9 @@ func (gw *Gateway) refresh() error {
 
 	rc.HTTPServers = append(rc.HTTPServers, DefaultHTTPReverseProxyServers(&gw.cfg)...)
 
-	if err := gw.nm.WriteConfig(rc); err != nil {
+	if err := gw.nm.SetConfig(rc); err != nil {
 		return err
 	}
-	if err := gw.nm.Reload(); err != nil {
-		return err
-	}
-
 	return nil
 }
 


### PR DESCRIPTION
Farva currently reloads after every polling interval, regardless of whether
changes to the configuration have occurred. This may cause service blips in
clients that attempt to re-use a drained and closed connections.

WriteConfig and Reload have been replaced by new interface methods that
encompass whatever is necessary to make the underlying implementation accept
a new configuration. Our clever tricks around being efficient and only writing
configuration to disk, then reloading nginx are hidden away behind this new
abstraction.