### PR TITLE
Adding ability to disable fifo logging.

### DIFF
--- a/pkg/gateway/gateway.go
+++ b/pkg/gateway/gateway.go
@@ -150,12 +150,14 @@ func (gw *Gateway) refresh() error {
 
 func (gw *Gateway) Run() error {
 
-	fifoLogger := logpipe.NewLogPipe(gw.cfg.FifoPath)
-	if err := fifoLogger.Start(); err != nil {
-		logger.Log.Fatalf(
-			"Could not start fifo logger, exiting since this will cause NGINX to block: %s",
-			err,
-		)
+	if gw.cfg.FifoPath != "" {
+		fifoLogger := logpipe.NewLogPipe(gw.cfg.FifoPath)
+		if err := fifoLogger.Start(); err != nil {
+			logger.Log.Fatalf(
+				"Could not start fifo logger, exiting since this will cause NGINX to block: %s",
+				err,
+			)
+		}
 	}
 
 	if err := gw.start(); err != nil {

--- a/pkg/gateway/reverseproxy_nginx.go
+++ b/pkg/gateway/reverseproxy_nginx.go
@@ -13,7 +13,11 @@ import (
 var (
 	nginxTemplateData = `
 pid {{ .NGINXConfig.PIDFile }};
+{{- if .NGINXConfig.ErrorLog }}
 error_log {{ .NGINXConfig.ErrorLog }};
+{{- else }}
+error_log off;
+{{- end }}
 daemon on;
 worker_processes auto;
 
@@ -26,7 +30,11 @@ http {
     log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
                       '$status $body_bytes_sent "$http_referer" '
                       '"$http_user_agent" "$http_x_forwarded_for"';
+    {{- if .NGINXConfig.AccessLog }}
     access_log {{ .NGINXConfig.AccessLog }} main;
+    {{- else }}
+    access_log off;
+    {{- end }}
 
     proxy_http_version 1.1;
     proxy_set_header Connection "";


### PR DESCRIPTION
If the `fifo-path` is left unspecified we disable fifo logging - the fifo
is never created, and we disable error_log and access_log.

The intent here it exercise the impact of logging on performance.
